### PR TITLE
Avoid error if _snakeForward if polyline is not on the map

### DIFF
--- a/L.Polyline.SnakeAnim.js
+++ b/L.Polyline.SnakeAnim.js
@@ -75,6 +75,8 @@ L.Polyline.include({
 
 	_snakeForward: function(forward) {
 
+		// If polyline has been removed from the map stop _snakeForward
+		if (this._map == null) return;
 		// Calculate distance from current vertex to next vertex
 		var currPoint = this._map.latLngToContainerPoint(
 			this._snakeLatLngs[ this._snakingRings ][ this._snakingVertices ]);

--- a/L.Polyline.SnakeAnim.js
+++ b/L.Polyline.SnakeAnim.js
@@ -76,7 +76,7 @@ L.Polyline.include({
 	_snakeForward: function(forward) {
 
 		// If polyline has been removed from the map stop _snakeForward
-		if (this._map == null) return;
+		if (!this._map) return;
 		// Calculate distance from current vertex to next vertex
 		var currPoint = this._map.latLngToContainerPoint(
 			this._snakeLatLngs[ this._snakingRings ][ this._snakingVertices ]);


### PR DESCRIPTION
When Polyline is removed before the animation is finished the following error is thrown:
`Uncaught TypeError: Cannot read property 'latLngToContainerPoint' of null`
