### PR TITLE
Restore a flat latlngs array when required to match previous state.

### DIFF
--- a/L.Polyline.SnakeAnim.js
+++ b/L.Polyline.SnakeAnim.js
@@ -44,7 +44,8 @@ L.Polyline.include({
 		this._snakingVertices = this._snakingRings = this._snakingDistance = 0;
 
 		if (!this._snakeLatLngs) {
-			this._snakeLatLngs = L.Polyline._flat(this._latlngs) ?
+			this._flatLatLngs = L.Polyline._flat(this._latlngs);
+			this._snakeLatLngs = this._flatLatLngs ?
 				[ this._latlngs ] :
 				this._latlngs ;
 		}
@@ -126,7 +127,9 @@ L.Polyline.include({
 
 	_snakeEnd: function() {
 
-		this.setLatLngs(this._snakeLatLngs);
+		this.setLatLngs(this._flatLatLngs ?
+					this._snakeLatLngs[0]:
+					this._snakeLatLngs);
 		this._snaking = false;
 		this.fire('snakeend');
 


### PR DESCRIPTION
I ran into this situation.

Currently, if `path` is defined as a `L.Polyline` with a flat array for `_latlngs`, this is fine before any animation:

``` javascript
var latLngs = path.getLatLngs();

for(var i = 0; i < latLngs.length; i++){
  // do stuff
}
```

But then after the `_snakeEnd` call, `path.getLatLngs()` returns a nested array (reset at https://github.com/IvanSanchez/Leaflet.Polyline.SnakeAnim/blob/master/L.Polyline.SnakeAnim.js#L129) so the same piece of code doesn't go through the latlngs anymore.

I solved this by adding a flag at the first call to `snakeIn` in order to remember if the polyline `_latlngs` is a flat or nested array in the first place. This allows the `_snakeEnd` function to reset it just as it was so that calling `getLatLng()` will have a consistent behaviour before and after an animation.
