### PR TITLE
modify calling the deprecated method.

### DIFF
--- a/L.Polyline.SnakeAnim.js
+++ b/L.Polyline.SnakeAnim.js
@@ -44,7 +44,7 @@ L.Polyline.include({
 		this._snakingVertices = this._snakingRings = this._snakingDistance = 0;
 
 		if (!this._snakeLatLngs) {
-			this._snakeLatLngs = L.Polyline._flat(this._latlngs) ?
+			this._snakeLatLngs = L.Polyline.isFlat(this._latlngs) ?
 				[ this._latlngs ] :
 				this._latlngs ;
 		}


### PR DESCRIPTION
Deprecated use of _flat, use L.LineUtil.isFlat instead.