### PR TITLE
performance.now() time resolution workaround

### DIFF
--- a/L.Polyline.SnakeAnim.js
+++ b/L.Polyline.SnakeAnim.js
@@ -64,6 +64,7 @@ L.Polyline.include({
 
 		var now = performance.now();
 		var diff = now - this._snakingTime;	// In milliseconds
+		diff = (diff == 0 ? 0.001 : diff) // avoids low time resolution issues in some browsers
 		var forward = diff * this.options.snakingSpeed / 1000;	// In pixels
 		this._snakingTime = now;
 
@@ -74,7 +75,7 @@ L.Polyline.include({
 	},
 
 	_snakeForward: function(forward) {
-
+		// Avoid divide by zero bug 
 		// If polyline has been removed from the map stop _snakeForward
 		if (!this._map) return;
 		// Calculate distance from current vertex to next vertex

--- a/L.Polyline.SnakeAnim.js
+++ b/L.Polyline.SnakeAnim.js
@@ -75,7 +75,7 @@ L.Polyline.include({
 	},
 
 	_snakeForward: function(forward) {
-		// Avoid divide by zero bug 
+		
 		// If polyline has been removed from the map stop _snakeForward
 		if (!this._map) return;
 		// Calculate distance from current vertex to next vertex


### PR DESCRIPTION
#29 is caused by some browsers (especially Firefox from version 60-now) reporting time with a lower resolution than expected. This one-line fix ensures that `_snakeForward` will never try to move forward 0.0 pixels and start throwing `NaN`s everywhere.